### PR TITLE
fix(rtd): drop AGPL trove classifier (PEP 639 conflict)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,7 @@ version = "0.3.5"
 description = "AST-based linter enforcing SciTeX reproducible research patterns"
 readme = "README.md"
 license = "AGPL-3.0-only"
-classifiers = [
-    "License :: OSI Approved :: GNU Affero General Public License v3",
-]
+classifiers = []
 requires-python = ">=3.8"
 dependencies = ["scitex-dev"]
 authors = [{name = "Yusuke Watanabe", email = "ywatanabe@scitex.ai"}]


### PR DESCRIPTION
## Problem
RTD builds fail with \`setuptools.errors.InvalidConfigError: License classifiers have been superseded by license expressions (PEP 639).\`

## Fix
Drop the trove classifier; keep \`license = "AGPL-3.0-only"\`. Same fix as scitex-skills PR #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)