### PR TITLE
Merge develop → main: AGPL classifier fix + CI standardization

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -1,0 +1,62 @@
+name: Install Test (fresh venv)
+
+# Catches undeclared runtime deps that the package's own test suite misses.
+# A package can build, upload, and pass its own tests with the wrong
+# pyproject.toml — the bug only shows up when a fresh user runs
+# `pip install <pkg>` in a clean venv. This job reproduces that path.
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  workflow_dispatch:
+
+jobs:
+  install-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Build wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build --wheel
+
+      - name: Install + import in a fresh venv
+        run: |
+          python -m venv /tmp/clean-venv
+          /tmp/clean-venv/bin/pip install --upgrade pip
+          /tmp/clean-venv/bin/pip install dist/*.whl
+          # Import the package — fails on the first undeclared dep.
+          # Replace IMPORT_NAME if pyproject `[project].name` differs from
+          # the source layout (e.g. scitex-foo → scitex_foo).
+          PKG_NAME=$(python -c "import tomllib, sys; sys.stdout.write(tomllib.load(open('pyproject.toml','rb'))['project']['name'])")
+          IMPORT_NAME="${PKG_NAME//-/_}"
+          /tmp/clean-venv/bin/python -c "import ${IMPORT_NAME}; print(f'OK: {${IMPORT_NAME}.__name__}')"
+
+      - name: Audit declared deps vs actual imports (if scitex-dev available)
+        # Optional secondary check using scitex_dev.audit_dependencies(). Only
+        # runs if the runner has scitex-dev installed; non-fatal otherwise.
+        run: |
+          /tmp/clean-venv/bin/pip install scitex-dev || true
+          /tmp/clean-venv/bin/python -c "
+          try:
+              from scitex_dev import audit_dependencies
+          except ImportError:
+              print('scitex-dev not available; skipping audit')
+              import sys; sys.exit(0)
+          rep = audit_dependencies('.')
+          print(rep)
+          import sys
+          sys.exit(0 if rep.is_clean else 1)
+          "

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -37,23 +37,31 @@ jobs:
           python -m venv /tmp/clean-venv
           /tmp/clean-venv/bin/pip install --upgrade pip
           /tmp/clean-venv/bin/pip install dist/*.whl
-          # Import the package — fails on the first undeclared dep.
-          # Replace IMPORT_NAME if pyproject `[project].name` differs from
-          # the source layout (e.g. scitex-foo → scitex_foo).
-          PKG_NAME=$(python -c "import tomllib, sys; sys.stdout.write(tomllib.load(open('pyproject.toml','rb'))['project']['name'])")
-          IMPORT_NAME="${PKG_NAME//-/_}"
+          # Detect import name from src/ layout (the only directory under
+          # src/ that contains __init__.py). Works on every supported Python
+          # without needing tomllib (3.11+) or tomli (extra dep).
+          IMPORT_NAME=$(find src -maxdepth 2 -name __init__.py -printf '%h\n' \
+                          | head -1 | xargs -n1 basename)
+          if [ -z "$IMPORT_NAME" ]; then
+              echo "Could not detect import name under src/" >&2
+              exit 1
+          fi
+          echo "Importing $IMPORT_NAME ..."
           /tmp/clean-venv/bin/python -c "import ${IMPORT_NAME}; print(f'OK: {${IMPORT_NAME}.__name__}')"
 
-      - name: Audit declared deps vs actual imports (if scitex-dev available)
-        # Optional secondary check using scitex_dev.audit_dependencies(). Only
-        # runs if the runner has scitex-dev installed; non-fatal otherwise.
+      - name: Audit declared deps vs actual imports (best-effort)
+        # Secondary check using scitex_dev.audit_dependencies(). Non-fatal:
+        # skipped if scitex-dev isn't yet available on PyPI for this Python.
+        continue-on-error: true
         run: |
-          /tmp/clean-venv/bin/pip install scitex-dev || true
+          /tmp/clean-venv/bin/pip install scitex-dev 2>/dev/null || (
+              echo "scitex-dev not installable on this Python; skipping"
+              exit 0
+          )
           /tmp/clean-venv/bin/python -c "
           try:
               from scitex_dev import audit_dependencies
           except ImportError:
-              print('scitex-dev not available; skipping audit')
               import sys; sys.exit(0)
           rep = audit_dependencies('.')
           print(rep)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install package + dev deps
+      - name: Install package + dev deps + test plugins
         run: |
           pip install --upgrade pip
+          pip install pytest pytest-cov pytest-timeout
           pip install -e ".[dev]" || pip install -e .
       - name: Detect import name
         id: pkg

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,45 @@
+name: Test
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  schedule:
+    - cron: "0 7 * * *"  # nightly 07:00 UTC
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install package + dev deps
+        run: |
+          pip install --upgrade pip
+          pip install -e ".[dev]" || pip install -e .
+      - name: Detect import name
+        id: pkg
+        run: |
+          IMPORT_NAME=$(find src -maxdepth 2 -name __init__.py -printf '%h\n' | head -1 | xargs -n1 basename)
+          echo "import_name=${IMPORT_NAME}" >> "$GITHUB_OUTPUT"
+      - name: Run tests with coverage
+        run: |
+          python -m pytest "$GITHUB_WORKSPACE/tests/" -v --tb=short --timeout=120 \
+            --cov=src/${{ steps.pkg.outputs.import_name }} \
+            --cov-report=xml --cov-report=term
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.xml
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@
 
 # SciTeX Linter (<code>scitex-linter</code>)
 
+<!-- scitex-badges:start -->
+[![PyPI](https://img.shields.io/pypi/v/scitex-linter.svg)](https://pypi.org/project/scitex-linter/)
+[![Python](https://img.shields.io/pypi/pyversions/scitex-linter.svg)](https://pypi.org/project/scitex-linter/)
+[![Tests](https://github.com/ywatanabe1989/scitex-linter/actions/workflows/test.yml/badge.svg)](https://github.com/ywatanabe1989/scitex-linter/actions/workflows/test.yml)
+[![Install Test](https://github.com/ywatanabe1989/scitex-linter/actions/workflows/install-test.yml/badge.svg)](https://github.com/ywatanabe1989/scitex-linter/actions/workflows/install-test.yml)
+[![Coverage](https://codecov.io/gh/ywatanabe1989/scitex-linter/graph/badge.svg)](https://codecov.io/gh/ywatanabe1989/scitex-linter)
+[![Docs](https://readthedocs.org/projects/scitex-linter/badge/?version=latest)](https://scitex-linter.readthedocs.io/en/latest/)
+[![License: AGPL v3](https://img.shields.io/badge/license-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
+<!-- scitex-badges:end -->
+
+
 <p align="center">
   <a href="https://scitex.ai">
     <img src="docs/scitex-logo-banner.png" alt="SciTeX Linter" width="400">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,14 @@ Documentation = "https://scitex-linter.readthedocs.io"
 Repository = "https://github.com/ywatanabe1989/scitex-linter"
 
 [project.optional-dependencies]
-mcp = ["fastmcp>=2.0.0"]
+mcp = [
+    "fastmcp>=2.0.0",
+]
+dev = [
+    "pytest",
+    "pytest-cov",
+    "ruff",
+]
 docs = [
     "sphinx>=7.0",
     "sphinx-rtd-theme>=2.0",
@@ -26,15 +33,8 @@ docs = [
     "sphinx-copybutton>=0.5",
     "sphinx-autodoc-typehints>=1.25",
 ]
-dev = [
-    "pytest",
-    "pytest-cov",
-    "ruff",
-]
 all = [
     "scitex-linter[mcp]",
-    "scitex-linter[docs]",
-    "scitex-linter[dev]",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,7 @@ version = "0.3.5"
 description = "AST-based linter enforcing SciTeX reproducible research patterns"
 readme = "README.md"
 license = "AGPL-3.0-only"
-classifiers = [
-    "License :: OSI Approved :: GNU Affero General Public License v3",
-]
+classifiers = []
 requires-python = ">=3.8"
 dependencies = ["scitex-dev"]
 authors = [{name = "Yusuke Watanabe", email = "ywatanabe@scitex.ai"}]

--- a/src/scitex_linter/__init__.py
+++ b/src/scitex_linter/__init__.py
@@ -3,6 +3,7 @@
 try:
     from importlib.metadata import PackageNotFoundError
     from importlib.metadata import version as _v
+
     try:
         __version__ = _v("scitex-linter")
     except PackageNotFoundError:
@@ -10,6 +11,8 @@ try:
     del _v, PackageNotFoundError
 except ImportError:  # pragma: no cover — only on ancient Pythons
     __version__ = "0.0.0+local"
+
+
 def list_rules(category: str = None) -> list:
     """Return all rules (built-in + plugin), optionally filtered by category.
 

--- a/src/scitex_linter/__init__.py
+++ b/src/scitex_linter/__init__.py
@@ -1,7 +1,8 @@
 """SciTeX Linter — enforce reproducible research patterns via AST analysis."""
 
 try:
-    from importlib.metadata import version as _v, PackageNotFoundError
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _v
     try:
         __version__ = _v("scitex-linter")
     except PackageNotFoundError:

--- a/src/scitex_linter/__init__.py
+++ b/src/scitex_linter/__init__.py
@@ -1,8 +1,14 @@
 """SciTeX Linter — enforce reproducible research patterns via AST analysis."""
 
-__version__ = "0.3.3"
-
-
+try:
+    from importlib.metadata import version as _v, PackageNotFoundError
+    try:
+        __version__ = _v("scitex-linter")
+    except PackageNotFoundError:
+        __version__ = "0.0.0+local"
+    del _v, PackageNotFoundError
+except ImportError:  # pragma: no cover — only on ancient Pythons
+    __version__ = "0.0.0+local"
 def list_rules(category: str = None) -> list:
     """Return all rules (built-in + plugin), optionally filtered by category.
 

--- a/tests/test_ipynb_linting.py
+++ b/tests/test_ipynb_linting.py
@@ -80,8 +80,6 @@ class TestIpynbLinting:
             ],
         )
         issues = lint_file(str(nb))
-        # At least one issue should tag the second cell
-        cell_refs = [getattr(i, "source_line", "") for i in issues]
         # Filepath is prefixed onto issues via lint_source; the only way
         # to verify here is that at least some issues came out of the np.save.
         assert any(i.rule.id == "STX-IO001" for i in issues)

--- a/tests/test_skills_quality.py
+++ b/tests/test_skills_quality.py
@@ -2,6 +2,7 @@
 Canonical: src/scitex/_skills/general/21_scitex-package-quality-checklist.md
 """
 from pathlib import Path
+
 from scitex_dev._skills_quality_pytest import make_skill_quality_tests
 
 test_skills_quality = make_skill_quality_tests(

--- a/tests/test_skills_quality.py
+++ b/tests/test_skills_quality.py
@@ -1,6 +1,7 @@
 """Enforces SciTeX skills quality checklist §1–§4.
 Canonical: src/scitex/_skills/general/21_scitex-package-quality-checklist.md
 """
+
 from pathlib import Path
 
 from scitex_dev._skills_quality_pytest import make_skill_quality_tests


### PR DESCRIPTION
## Summary

- Drops legacy `License :: OSI Approved :: GNU Affero General Public License v3` trove classifier (PEP 639 conflict — setuptools >=80 fails the build)
- Switches `__version__` to `importlib.metadata` (E5F1 fixer)
- Standardizes test.yml (matrix + cov + Codecov)
- Adds install-test workflow (fresh venv import smoke)

## Why

`main` CI red on every Python (`test (3.9..3.12)` Install dependencies) — pip-build fails because setuptools rejects the AGPL classifier under PEP 639. Fix is in commit `984605b` on develop.

## Test plan

- [ ] Tests workflow green across the matrix
- [ ] Install Test green